### PR TITLE
Improve touch control layout and responsiveness

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,14 +47,18 @@
             </div>
             <canvas id="gameCanvas"></canvas>
             <div id="controls">
-                <div class="control-group">
-                    <button class="control-btn" id="leftBtn">←</button>
-                    <button class="control-btn" id="rightBtn">→</button>
-                    <button class="control-btn" id="jumpBtn">ジャンプ</button>
-                </div>
-                <div class="control-group">
-                    <button class="control-btn" id="attackBtn">攻撃</button>
+                <div id="weaponControl">
                     <button class="control-btn" id="weaponBtn">武器変更</button>
+                </div>
+                <div id="rightControls">
+                    <div class="control-group">
+                        <button class="control-btn" id="leftBtn">←</button>
+                        <button class="control-btn" id="rightBtn">→</button>
+                    </div>
+                    <div class="control-group">
+                        <button class="control-btn" id="jumpBtn">ジャンプ</button>
+                        <button class="control-btn" id="attackBtn">攻撃</button>
+                    </div>
                 </div>
             </div>
         </div>

--- a/script.js
+++ b/script.js
@@ -437,36 +437,42 @@ function setupTouchControls() {
     const attackBtn = document.getElementById('attackBtn');
     const weaponBtn = document.getElementById('weaponBtn');
     
-    // タッチ開始・終了イベント
-    leftBtn.addEventListener('touchstart', (e) => {
+    // ポインタイベント
+    leftBtn.addEventListener('pointerdown', (e) => {
         e.preventDefault();
         keys['arrowleft'] = true;
     });
-    leftBtn.addEventListener('touchend', (e) => {
+    leftBtn.addEventListener('pointerup', (e) => {
         e.preventDefault();
         keys['arrowleft'] = false;
     });
-    
-    rightBtn.addEventListener('touchstart', (e) => {
+    leftBtn.addEventListener('pointerout', () => {
+        keys['arrowleft'] = false;
+    });
+
+    rightBtn.addEventListener('pointerdown', (e) => {
         e.preventDefault();
         keys['arrowright'] = true;
     });
-    rightBtn.addEventListener('touchend', (e) => {
+    rightBtn.addEventListener('pointerup', (e) => {
         e.preventDefault();
         keys['arrowright'] = false;
     });
-    
-    jumpBtn.addEventListener('touchstart', (e) => {
+    rightBtn.addEventListener('pointerout', () => {
+        keys['arrowright'] = false;
+    });
+
+    jumpBtn.addEventListener('pointerdown', (e) => {
         e.preventDefault();
         if (gameState.gameRunning) player.jump();
     });
-    
-    attackBtn.addEventListener('touchstart', (e) => {
+
+    attackBtn.addEventListener('pointerdown', (e) => {
         e.preventDefault();
         if (gameState.gameRunning) player.shoot();
     });
-    
-    weaponBtn.addEventListener('touchstart', (e) => {
+
+    weaponBtn.addEventListener('pointerdown', (e) => {
         e.preventDefault();
         if (gameState.gameRunning) switchWeapon();
     });

--- a/style.css
+++ b/style.css
@@ -215,11 +215,23 @@ button:active {
 #controls {
   position: absolute;
   bottom: 20px;
+  left: 0;
+  width: 100%;
+  z-index: 100;
+}
+
+#weaponControl {
+  position: absolute;
   left: 50%;
   transform: translateX(-50%);
+}
+
+#rightControls {
+  position: absolute;
+  right: 20px;
   display: flex;
-  gap: 20px;
-  z-index: 100;
+  flex-direction: column;
+  gap: 10px;
 }
 
 .control-group {
@@ -288,20 +300,23 @@ button:active {
   
   #controls {
       bottom: 10px;
-      gap: 15px;
   }
-  
+
+  #rightControls {
+      gap: 8px;
+  }
+
   .control-group {
       gap: 8px;
   }
 }
 
 @media (max-width: 480px) {
-  #controls {
-      flex-direction: column;
-      gap: 10px;
+  #rightControls {
+      right: 10px;
+      gap: 6px;
   }
-  
+
   .control-group {
       justify-content: center;
   }
@@ -316,6 +331,6 @@ button:active {
   
   #controls {
       bottom: 5px;
-      transform: translateX(-50%) scale(0.9);
+      transform: scale(0.9);
   }
 }


### PR DESCRIPTION
## Summary
- Center weapon change button and move movement/jump/attack controls to the right
- Adjust CSS for new layout and responsive spacing
- Switch to pointer events for faster touch/mouse response

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68928071dcb88330a395f0d81d78b97f