### PR TITLE
Adjust layout to split action and control areas

### DIFF
--- a/script.js
+++ b/script.js
@@ -387,7 +387,7 @@ function init() {
 function resizeCanvas() {
     const container = document.getElementById('gameContainer');
     canvas.width = container.clientWidth;
-    canvas.height = container.clientHeight;
+    canvas.height = container.clientHeight * 0.8;
 }
 
 function setupEventListeners() {

--- a/style.css
+++ b/style.css
@@ -40,6 +40,12 @@ body {
   display: none !important;
 }
 
+#gameScreen {
+  justify-content: flex-start;
+  align-items: stretch;
+  padding: 0;
+}
+
 @keyframes fadeIn {
   from { opacity: 0; }
   to { opacity: 1; }
@@ -206,18 +212,18 @@ button:active {
 #gameCanvas {
   display: block;
   width: 100%;
-  height: 100%;
+  height: 80%;
   background: linear-gradient(180deg, #001122, #003366);
   image-rendering: pixelated;
 }
 
 /* タッチコントロール */
 #controls {
-  position: absolute;
-  bottom: 20px;
-  left: 50%;
-  transform: translateX(-50%);
+  width: 100%;
+  height: 20%;
   display: flex;
+  justify-content: center;
+  align-items: center;
   gap: 20px;
   z-index: 100;
 }
@@ -280,17 +286,16 @@ button:active {
       align-items: flex-start;
       gap: 10px;
   }
-  
+
   #playerInfo {
       flex-direction: row;
       gap: 15px;
   }
-  
+
   #controls {
-      bottom: 10px;
       gap: 15px;
   }
-  
+
   .control-group {
       gap: 8px;
   }
@@ -313,9 +318,8 @@ button:active {
       font-size: 0.8rem;
       padding: 15px;
   }
-  
+
   #controls {
-      bottom: 5px;
-      transform: translateX(-50%) scale(0.9);
+      transform: scale(0.9);
   }
 }


### PR DESCRIPTION
## Summary
- Reserve top four-fifths of the screen for gameplay and bottom fifth for control buttons
- Adjust canvas resizing logic to match new layout proportions

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_6892c197d6d88330b18728c8b2b343aa