### PR TITLE
Refine mobile control layout and canvas sizing

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,12 +47,14 @@
             </div>
             <canvas id="gameCanvas"></canvas>
             <div id="controls">
-                <div class="control-group">
-                    <button class="control-btn" id="leftBtn">←</button>
-                    <button class="control-btn" id="rightBtn">→</button>
+                <div class="control-group left-controls">
                     <button class="control-btn" id="jumpBtn">ジャンプ</button>
                 </div>
-                <div class="control-group">
+                <div class="control-group center-controls">
+                    <button class="control-btn" id="leftBtn">←</button>
+                    <button class="control-btn" id="rightBtn">→</button>
+                </div>
+                <div class="control-group right-controls">
                     <button class="control-btn" id="attackBtn">攻撃</button>
                     <button class="control-btn" id="weaponBtn">武器変更</button>
                 </div>

--- a/style.css
+++ b/style.css
@@ -138,6 +138,7 @@ button:active {
 /* ゲーム画面 */
 #gameScreen {
   padding: 0;
+  justify-content: flex-start;
 }
 
 #gameUI {
@@ -206,7 +207,7 @@ button:active {
 #gameCanvas {
   display: block;
   width: 100%;
-  height: 100%;
+  height: 80vh;
   background: linear-gradient(180deg, #001122, #003366);
   image-rendering: pixelated;
 }
@@ -215,16 +216,25 @@ button:active {
 #controls {
   position: absolute;
   bottom: 20px;
-  left: 50%;
-  transform: translateX(-50%);
+  left: 0;
+  width: 100%;
   display: flex;
-  gap: 20px;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0 20px;
   z-index: 100;
 }
 
-.control-group {
+.left-controls,
+.center-controls,
+.right-controls {
   display: flex;
   gap: 10px;
+}
+
+.center-controls {
+  flex: 1;
+  justify-content: center;
 }
 
 .control-btn {
@@ -280,18 +290,20 @@ button:active {
       align-items: flex-start;
       gap: 10px;
   }
-  
+
   #playerInfo {
       flex-direction: row;
       gap: 15px;
   }
-  
+
   #controls {
       bottom: 10px;
-      gap: 15px;
+      padding: 0 10px;
   }
-  
-  .control-group {
+
+  .left-controls,
+  .center-controls,
+  .right-controls {
       gap: 8px;
   }
 }
@@ -299,10 +311,11 @@ button:active {
 @media (max-width: 480px) {
   #controls {
       flex-direction: column;
+      align-items: center;
       gap: 10px;
   }
-  
-  .control-group {
+
+  .center-controls {
       justify-content: center;
   }
 }
@@ -313,9 +326,9 @@ button:active {
       font-size: 0.8rem;
       padding: 15px;
   }
-  
+
   #controls {
       bottom: 5px;
-      transform: translateX(-50%) scale(0.9);
+      transform: scale(0.9);
   }
 }


### PR DESCRIPTION
## Summary
- Resize gameplay canvas to occupy top 80% of the screen.
- Position jump button on the left, movement buttons centrally, and attack/weapon controls on the right.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6892c4426d9c833097c2580e987620cb