### PR TITLE
Refactor mobile controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,16 +55,15 @@
                 </div>
             </div>
             <canvas id="gameCanvas"></canvas>
-            <div id="controls">
-                <div class="control-group">
-                    <button class="control-btn" id="leftBtn">←</button>
-                    <button class="control-btn" id="rightBtn">→</button>
-                    <button class="control-btn" id="jumpBtn">⬆</button>
-                </div>
-                <div class="control-group">
-                    <button class="control-btn" id="attackBtn">🔫</button>
-                    <button class="control-btn" id="weaponBtn">🔄</button>
-                </div>
+            <div id="controls-left">
+                <button id="left">←</button>
+                <button id="right">→</button>
+                <button id="jump">↑</button>
+            </div>
+            <div id="controls-right">
+                <button id="attack">🔫</button>
+                <button id="reload">🔁</button>
+                <button id="switchWeapon">🔄</button>
             </div>
         </div>
 

--- a/script.js
+++ b/script.js
@@ -421,6 +421,7 @@ let enemyBullets = [];
 let keys = {};
 let lastTime = 0;
 let hudHpFill, enemyCountEl, bulletCountEl;
+const activeTouches = new Set();
 
 // ステージ情報
 const stageData = [
@@ -437,10 +438,22 @@ const stageData = [
 function init() {
     canvas = document.getElementById('gameCanvas');
     ctx = canvas.getContext('2d');
-    
+
     // キャンバスサイズ設定
     resizeCanvas();
     window.addEventListener('resize', resizeCanvas);
+
+    canvas.addEventListener('touchstart', (e) => {
+        for (let touch of e.touches) {
+            activeTouches.add(touch.identifier);
+        }
+    });
+
+    canvas.addEventListener('touchend', (e) => {
+        for (let touch of e.changedTouches) {
+            activeTouches.delete(touch.identifier);
+        }
+    });
     
     // ゲーム状態初期化
     gameState = new GameState();
@@ -503,12 +516,13 @@ function setupEventListeners() {
 }
 
 function setupTouchControls() {
-    const leftBtn = document.getElementById('leftBtn');
-    const rightBtn = document.getElementById('rightBtn');
-    const jumpBtn = document.getElementById('jumpBtn');
-    const attackBtn = document.getElementById('attackBtn');
-    const weaponBtn = document.getElementById('weaponBtn');
-    
+    const leftBtn = document.getElementById('left');
+    const rightBtn = document.getElementById('right');
+    const jumpBtn = document.getElementById('jump');
+    const attackBtn = document.getElementById('attack');
+    const reloadBtn = document.getElementById('reload');
+    const switchBtn = document.getElementById('switchWeapon');
+
     // タッチ開始・終了イベント
     leftBtn.addEventListener('touchstart', (e) => {
         e.preventDefault();
@@ -518,7 +532,7 @@ function setupTouchControls() {
         e.preventDefault();
         keys['arrowleft'] = false;
     });
-    
+
     rightBtn.addEventListener('touchstart', (e) => {
         e.preventDefault();
         keys['arrowright'] = true;
@@ -527,18 +541,23 @@ function setupTouchControls() {
         e.preventDefault();
         keys['arrowright'] = false;
     });
-    
+
     jumpBtn.addEventListener('touchstart', (e) => {
         e.preventDefault();
         if (gameState.gameRunning) player.jump();
     });
-    
+
     attackBtn.addEventListener('touchstart', (e) => {
         e.preventDefault();
         if (gameState.gameRunning) player.shoot();
     });
-    
-    weaponBtn.addEventListener('touchstart', (e) => {
+
+    reloadBtn.addEventListener('touchstart', (e) => {
+        e.preventDefault();
+        if (gameState.gameRunning) reloadWeapon();
+    });
+
+    switchBtn.addEventListener('touchstart', (e) => {
         e.preventDefault();
         if (gameState.gameRunning) switchWeapon();
     });
@@ -555,7 +574,7 @@ function startGame() {
     gameState.gameRunning = true;
     
     // プレイヤー初期化
-    player = new Player(100, canvas.height - 200);
+    player = new Player(100, canvas.height * 0.5);
     
     // ステージ初期化
     initStage(gameState.currentStage);
@@ -601,6 +620,10 @@ function updateUI() {
 function updateWeaponDisplay() {
     const weaponName = gameState.unlockedWeapons[gameState.currentWeapon];
     document.getElementById('currentWeapon').textContent = `武器: ${weaponName}`;
+}
+
+function reloadWeapon() {
+    // TODO: implement reloading
 }
 
 function switchWeapon() {
@@ -780,7 +803,7 @@ function nextStage() {
     
     // プレイヤー位置リセット
     player.x = 100;
-    player.y = canvas.height - 200;
+    player.y = canvas.height * 0.5;
     player.velocityX = 0;
     player.velocityY = 0;
     

--- a/style.css
+++ b/style.css
@@ -264,40 +264,40 @@ button:active {
 }
 
 /* タッチコントロール */
-#controls {
-  position: absolute;
+#controls-left,
+#controls-right {
+  position: fixed;
   bottom: 20px;
-  left: 50%;
-  transform: translateX(-50%);
+  width: 40%;
   display: flex;
-  gap: 20px;
-  z-index: 100;
+  justify-content: space-around;
+  z-index: 1000;
 }
 
-.control-group {
-  display: flex;
-  gap: 10px;
+#controls-left {
+  left: 0;
 }
 
-.control-btn {
-  width: clamp(60px, 15vw, 90px);
-  height: clamp(60px, 15vw, 90px);
+#controls-right {
+  right: 0;
+}
+
+#controls-left button,
+#controls-right button {
+  width: 80px;
+  height: 80px;
   border-radius: 50%;
-  background: rgba(173, 216, 230, 0.25);
-  border: 2px solid rgba(173, 216, 230, 0.6);
-  color: #e0e0e0;
-  font-size: clamp(1.2rem, 3vw, 1.6rem);
-  font-weight: normal;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  touch-action: manipulation;
-  user-select: none;
+  font-size: 1.2rem;
+  background-color: #222;
+  color: white;
+  border: 2px solid lime;
+  padding: 0;
 }
 
-.control-btn:active {
-  background: rgba(173, 216, 230, 0.5);
-  transform: scale(0.9);
+#controls-left button:active,
+#controls-right button:active {
+  background-color: #555;
+  transform: scale(0.95);
 }
 
 /* クリア・ゲームオーバー画面 */
@@ -338,25 +338,9 @@ button:active {
       gap: 15px;
   }
   
-  #controls {
-      bottom: 10px;
-      gap: 15px;
-  }
-  
-  .control-group {
-      gap: 8px;
-  }
 }
 
 @media (max-width: 480px) {
-  #controls {
-      flex-direction: column;
-      gap: 10px;
-  }
-  
-  .control-group {
-      justify-content: center;
-  }
 }
 
 /* 縦画面での調整 */
@@ -366,8 +350,4 @@ button:active {
       padding: 15px;
   }
   
-  #controls {
-      bottom: 5px;
-      transform: translateX(-50%) scale(0.9);
-  }
 }


### PR DESCRIPTION
## Summary
- Split on-screen controls into left/right panels
- Style larger action buttons and center player higher on the screen
- Add canvas multitouch tracking and reload button stub

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68946fe1d1d48330a0b3dbec609ec340