### PR TITLE
Add mobile-friendly control layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,15 +55,14 @@
                 </div>
             </div>
             <canvas id="gameCanvas"></canvas>
-            <div id="controls-left">
-                <button id="left">←</button>
-                <button id="right">→</button>
-                <button id="jump">↑</button>
+            <div id="left-controls">
+                <button id="btn-left">←</button>
+                <button id="btn-right">→</button>
             </div>
-            <div id="controls-right">
-                <button id="attack">🔫</button>
-                <button id="reload">🔁</button>
-                <button id="switchWeapon">🔄</button>
+            <div id="right-controls">
+                <button id="btn-switch">🔁</button>
+                <button id="btn-fire">🔫</button>
+                <button id="btn-jump">⬆️</button>
             </div>
         </div>
 

--- a/script.js
+++ b/script.js
@@ -420,6 +420,7 @@ let bullets = [];
 let enemyBullets = [];
 let keys = {};
 let lastTime = 0;
+let fireInterval;
 let hudHpFill, enemyCountEl, bulletCountEl;
 const activeTouches = new Set();
 
@@ -516,51 +517,73 @@ function setupEventListeners() {
 }
 
 function setupTouchControls() {
-    const leftBtn = document.getElementById('left');
-    const rightBtn = document.getElementById('right');
-    const jumpBtn = document.getElementById('jump');
-    const attackBtn = document.getElementById('attack');
-    const reloadBtn = document.getElementById('reload');
-    const switchBtn = document.getElementById('switchWeapon');
+    const leftBtn = document.getElementById('btn-left');
+    const rightBtn = document.getElementById('btn-right');
+    const fireBtn = document.getElementById('btn-fire');
+    const switchBtn = document.getElementById('btn-switch');
+    const jumpBtn = document.getElementById('btn-jump');
 
-    // タッチ開始・終了イベント
     leftBtn.addEventListener('touchstart', (e) => {
         e.preventDefault();
-        keys['arrowleft'] = true;
+        moveLeft();
     });
     leftBtn.addEventListener('touchend', (e) => {
         e.preventDefault();
-        keys['arrowleft'] = false;
+        stopMoveLeft();
     });
 
     rightBtn.addEventListener('touchstart', (e) => {
         e.preventDefault();
-        keys['arrowright'] = true;
+        moveRight();
     });
     rightBtn.addEventListener('touchend', (e) => {
         e.preventDefault();
-        keys['arrowright'] = false;
-    });
-
-    jumpBtn.addEventListener('touchstart', (e) => {
-        e.preventDefault();
-        if (gameState.gameRunning) player.jump();
-    });
-
-    attackBtn.addEventListener('touchstart', (e) => {
-        e.preventDefault();
-        if (gameState.gameRunning) player.shoot();
-    });
-
-    reloadBtn.addEventListener('touchstart', (e) => {
-        e.preventDefault();
-        if (gameState.gameRunning) reloadWeapon();
+        stopMoveRight();
     });
 
     switchBtn.addEventListener('touchstart', (e) => {
         e.preventDefault();
         if (gameState.gameRunning) switchWeapon();
     });
+
+    fireBtn.addEventListener('touchstart', (e) => {
+        e.preventDefault();
+        fire();
+        fireInterval = setInterval(fire, 200);
+    });
+    fireBtn.addEventListener('touchend', (e) => {
+        e.preventDefault();
+        clearInterval(fireInterval);
+    });
+
+    jumpBtn.addEventListener('touchstart', (e) => {
+        e.preventDefault();
+        jump();
+    });
+}
+
+function moveLeft() {
+    keys['arrowleft'] = true;
+}
+
+function stopMoveLeft() {
+    keys['arrowleft'] = false;
+}
+
+function moveRight() {
+    keys['arrowright'] = true;
+}
+
+function stopMoveRight() {
+    keys['arrowright'] = false;
+}
+
+function fire() {
+    if (gameState.gameRunning) player.shoot();
+}
+
+function jump() {
+    if (gameState.gameRunning) player.jump();
 }
 
 function showScreen(screenId) {

--- a/style.css
+++ b/style.css
@@ -264,28 +264,27 @@ button:active {
 }
 
 /* タッチコントロール */
-#controls-left,
-#controls-right {
+#left-controls,
+#right-controls {
   position: fixed;
   bottom: 20px;
-  width: 40%;
   display: flex;
-  justify-content: space-around;
+  gap: 10px;
   z-index: 1000;
 }
 
-#controls-left {
-  left: 0;
+#left-controls {
+  left: 20px;
 }
 
-#controls-right {
-  right: 0;
+#right-controls {
+  right: 20px;
 }
 
-#controls-left button,
-#controls-right button {
-  width: 80px;
-  height: 80px;
+#left-controls button,
+#right-controls button {
+  width: 60px;
+  height: 60px;
   border-radius: 50%;
   font-size: 1.2rem;
   background-color: #222;
@@ -294,8 +293,8 @@ button:active {
   padding: 0;
 }
 
-#controls-left button:active,
-#controls-right button:active {
+#left-controls button:active,
+#right-controls button:active {
   background-color: #555;
   transform: scale(0.95);
 }


### PR DESCRIPTION
## Summary
- Rework mobile controls with new left/right and weapon/fire/jump buttons.
- Style controls as fixed bottom elements for thumb-friendly use.
- Wire touch events to movement, firing, and weapon switching with hold support.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894949197e4833086f7748b62c42f0a