### PR TITLE
Make controls circular and disable double-tap zoom

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="ja">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <title>CODE BREAKERS - コードブレイカーズ</title>
     <link rel="stylesheet" href="style.css">
 </head>

--- a/script.js
+++ b/script.js
@@ -445,16 +445,22 @@ function init() {
     window.addEventListener('resize', resizeCanvas);
 
     canvas.addEventListener('touchstart', (e) => {
+        e.preventDefault();
         for (let touch of e.touches) {
             activeTouches.add(touch.identifier);
         }
-    });
+    }, { passive: false });
 
     canvas.addEventListener('touchend', (e) => {
+        e.preventDefault();
         for (let touch of e.changedTouches) {
             activeTouches.delete(touch.identifier);
         }
-    });
+    }, { passive: false });
+
+    canvas.addEventListener('touchmove', (e) => {
+        e.preventDefault();
+    }, { passive: false });
     
     // ゲーム状態初期化
     gameState = new GameState();

--- a/style.css
+++ b/style.css
@@ -11,6 +11,7 @@ body {
   color: #00ff41;
   overflow: hidden;
   user-select: none;
+  touch-action: manipulation;
 }
 
 #gameContainer {
@@ -291,6 +292,10 @@ button:active {
   color: white;
   border: 2px solid lime;
   padding: 0;
+  aspect-ratio: 1 / 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 #left-controls button:active,


### PR DESCRIPTION
## Summary
- Ensure on-screen control buttons render as perfect circles
- Prevent double-tap gestures from causing page zoom or jitter

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68949f73c2d483308241ed25671d9e2e