### PR TITLE
Arrange touch controls in single row

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,14 +55,12 @@
                 </div>
             </div>
             <canvas id="gameCanvas"></canvas>
-            <div id="left-controls">
-                <button id="btn-left">←</button>
-                <button id="btn-right">→</button>
-            </div>
-            <div id="right-controls">
-                <button id="btn-switch">🔁</button>
-                <button id="btn-fire">🔫</button>
+            <div id="controls">
+                <button id="btn-left">⬅️</button>
+                <button id="btn-right">➡️</button>
+                <button id="btn-switch">チェンジ</button>
                 <button id="btn-jump">⬆️</button>
+                <button id="btn-fire">攻撃</button>
             </div>
         </div>
 

--- a/style.css
+++ b/style.css
@@ -265,29 +265,21 @@ button:active {
 }
 
 /* タッチコントロール */
-#left-controls,
-#right-controls {
+#controls {
   position: fixed;
   bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%);
   display: flex;
   gap: 10px;
   z-index: 1000;
 }
 
-#left-controls {
-  left: 20px;
-}
-
-#right-controls {
-  right: 20px;
-}
-
-#left-controls button,
-#right-controls button {
+#controls button {
   width: 60px;
   height: 60px;
   border-radius: 50%;
-  font-size: 1.2rem;
+  font-size: 0.9rem;
   background-color: #222;
   color: white;
   border: 2px solid lime;
@@ -298,8 +290,7 @@ button:active {
   justify-content: center;
 }
 
-#left-controls button:active,
-#right-controls button:active {
+#controls button:active {
   background-color: #555;
   transform: scale(0.95);
 }


### PR DESCRIPTION
## Summary
- Combine left and right touch control groups into a single centered row with five buttons for left, right, change, jump, and attack.
- Style new control row with equal-sized circular buttons and remove old positioning rules.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689567233c408330a9666384d3f31e93