### PR TITLE
Automatically advance to next stage after enemies defeated

### DIFF
--- a/script.js
+++ b/script.js
@@ -475,6 +475,7 @@ let lastTime = 0;
 let fireInterval;
 let hudHpFill, enemyCountEl, bulletCountEl;
 const activeTouches = new Set();
+let nextStageTimeout; // 次ステージへの自動移行用タイマー
 
 // ステージ情報
 const stageData = [
@@ -906,10 +907,18 @@ function stageClear() {
     } else {
         // ステージクリア画面
         showScreen('stageClearScreen');
+        // 一定時間後に自動で次のステージへ
+        nextStageTimeout = setTimeout(nextStage, 2000);
     }
 }
 
 function nextStage() {
+    // 自動移行用タイマーがある場合はクリア
+    if (nextStageTimeout) {
+        clearTimeout(nextStageTimeout);
+        nextStageTimeout = null;
+    }
+
     gameState.currentStage++;
     gameState.playerHP = gameState.maxHP; // HP全回復
     


### PR DESCRIPTION
## Summary
- Add timer to trigger automatic transition to the next stage after clearing enemies
- Clear pending timer when next stage is manually triggered to avoid double increments

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68971734513083309c35de60c0ae4181