### PR TITLE
Advance to next stage after boss defeat

### DIFF
--- a/script.js
+++ b/script.js
@@ -849,8 +849,8 @@ function update() {
 
     updateHUD();
 
-    // ステージクリア判定
-    if (enemies.length === 0) {
+    // ステージクリア判定（ボス撃破でクリア）
+    if (!enemies.some(enemy => enemy.type === 'boss')) {
         stageClear();
     }
 }


### PR DESCRIPTION
## Summary
- Clear stage as soon as the boss is defeated instead of waiting for all enemies

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_689ea6a9adbc8330b384345445609cf2