### PR TITLE
Add balanced placeholder spaces to title screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,6 +26,11 @@
                     <li>武器変更: Cキー / 武器変更ボタン</li>
                 </ul>
             </div>
+            <div class="space-container">
+                <div class="space-box"></div>
+                <div class="space-box"></div>
+                <div class="space-box"></div>
+            </div>
         </div>
 
         <div id="gameScreen" class="screen hidden">

--- a/style.css
+++ b/style.css
@@ -106,6 +106,22 @@ body {
   color: #ffffff;
 }
 
+#titleScreen .space-container {
+  display: flex;
+  justify-content: space-between;
+  width: 80%;
+  max-width: 600px;
+  margin-top: 30px;
+  gap: 20px;
+}
+
+#titleScreen .space-box {
+  flex: 1;
+  height: 80px;
+  border: 2px dashed #00ff41;
+  background: rgba(255, 255, 255, 0.05);
+}
+
 @keyframes glow {
   from { text-shadow: 0 0 20px #00ff41; }
   to { text-shadow: 0 0 30px #00ff41, 0 0 40px #00ff41; }


### PR DESCRIPTION
## Summary
- Add three empty placeholders to the title screen for balanced layout
- Style placeholders with flexbox for even spacing and dashed borders

## Testing
- `node --version`
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68c0263da2788330aaa51d7918b75d5d